### PR TITLE
Fix CI deploy and improve configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ git:
   # - Aside of merge commit we need a previous commit to be able to detect a version switch
   depth: 10
 
+cache:
+  # Not relying on 'npm' shortcut, as per Travis docs it's the only 'node_modules' that it'll cache
+  directories:
+    - $HOME/.npm
+    - node_modules
+
 branches:
   only:
     - master # Do not build PR branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,8 @@ jobs:
       deploy:
         provider: npm
         email: services@serverless.com
+        on:
+          tags: true
         api_key:
           secure: TR0iwraM6LkJFqKIjPbHP04yE4HYD0bY4jTGrf8TQTgeOUw3jF/5vLXU5XORYypWSgxmehKUaeeo8YC0QuC72NF37DkvzmwS7ENoIwcOxEtrIYjWhWVWBsPN8qfM5gFj0k4KY1clvamdTOTQ+yg5od7iYIDhg3L2CM3yMAsx/MifMYZbYvXIUGeXuoohd2XTwh89kSMMoae/E+zSvvZANxByDOAliSM10O6kAn9UclrE8lILskmchuNurzqMpUkIJQuAYXUojYMnou5uZhRPWrtbyrcrv+QFb7LQmqHD3gSJemLrgjKM0/7IkPSirRcca6bixxrJYwCDvr35KkWHUibEbmgBJL1pyAmftBG5cL6qMQzBihLCQDy/dI+leR48uTWDlWA+eSy05vkmYEm5JoxY49R7wbMG/aZb1lZlz+M9+HgUuJO9spK1wIiQrqOV8oLizjMAUFy94xp7/kXImj0KVR6yk2cxBBqDyVAbINitF+h98hl7BPQepoCcj4Y5Mz8y20RPZsk0+Y1z5sfaXhCCeNcPgLqv8uKyDwcXfM1TgoFk9L52m5DfHpBKfm5THWqbY4THB1dpQfPkjZEREwDoFo+fAWefHcB+erJ+kbGl2kxZw/7T/TRZmM34ExFLbUkl4kF/Xc4s3b4QdFkbNfbHljn/2rhg+sFHR3j83FY=
       after_deploy: npx github-release-from-cc-changelog $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ install:
   # Note: npm documents --dev option for dev dependencies update, but it's only --save-dev that works
   - npm update --save-dev --no-save # Updates just devDependencies
 
+before_script:
+  # Fail build right after first script fails. Travis doesn't ensure that: https://github.com/travis-ci/travis-ci/issues/1066
+  # More info on below line: https://www.davidpashley.com/articles/writing-robust-shell-scripts/#idm5413512
+  - set -e
+
 jobs:
   include:
     # In most cases it's best to configure one job per platform & Node.js version combination
@@ -45,15 +50,16 @@ jobs:
       if: type = pull_request AND fork = false
       node_js: 12
       script:
+        - npm run prettier-check-updated
+        - npm run lint-updated
+        - npm run commitlint-ci-pull-request
+        # If release PR, confirm we have a changelog
         - |
-          npm run prettier-check-updated && npm run lint-updated && npm run commitlint-ci-pull-request &&
-          {
-            # If release PR, confirm we have a changelog
-            tagName=`git diff master package.json | grep '"version": "' | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"`
-            if [ $? -eq 0 ]; then
-              npx dump-release-notes-from-cc-changelog $tagName
-            fi
-          }
+          tagName=`git diff master package.json | grep '"version": "' | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
+          if [ -n "$tagName" ];
+          then
+            npx dump-release-notes-from-cc-changelog $tagName
+          fi
 
     # PR's from forks
     # Do not validate commit messages,
@@ -61,7 +67,9 @@ jobs:
     - name: 'Prettier check updated, Lint updated - Node.js v12'
       if: type = pull_request AND fork = true
       node_js: 12
-      script: npm run prettier-check-updated && npm run lint-updated
+      script:
+        - npm run prettier-check-updated
+        - npm run lint-updated
 
     # master branch
     - name: 'Lint, Tag on version bump - Node.js v12'
@@ -71,15 +79,14 @@ jobs:
       if: branch = master AND type = push
       node_js: 12
       script:
+        - npm run lint
+        # If package version was changed with last merged PR, push tag
         - |
-          npm run lint &&
-          {
-            # If package version was changed with last merged PR, push tag
-            tagName=`git diff HEAD^ package.json | grep '"version": "' | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"`
-            if [ $? -eq 0 ]; then
-              git tag v$tagName && git push -q https://$GITHUB_TOKEN@github.com/serverless/eslint-config --tags
-            fi
-          }
+          tagName=`git diff HEAD^ package.json | grep '"version": "' | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
+          if [  -n "$tagName" ];
+          then
+            git tag v$tagName && git push -q https://$GITHUB_TOKEN@github.com/serverless/eslint-config --tags
+          fi
 
     # version tag
     - stage: Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,13 @@ env:
   global:
     - FORCE_COLOR=1 # Ensure colored output (color support is not detected in some cases)
 
+# Ensure to install dependencies at their latest versions
+install:
+  # Note: with `npm update` there seems no way to update all project dependency groups in one run
+  - npm update --no-save # Updates just dependencies
+  # Note: npm documents --dev option for dev dependencies update, but it's only --save-dev that works
+  - npm update --save-dev --no-save # Updates just devDependencies
+
 jobs:
   include:
     # In most cases it's best to configure one job per platform & Node.js version combination

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ stages:
   - name: Deploy
     if: tag =~ ^v\d+\.\d+\.\d+$
 
+env:
+  global:
+    - FORCE_COLOR=1 # Ensure colored output (color support is not detected in some cases)
+
 jobs:
   include:
     # In most cases it's best to configure one job per platform & Node.js version combination

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 git:
-  # Do not take whole history, but ensure to not break things:
+  # Minimize git history, but ensure to not break things:
   # - Merging multiple PR's around same time may introduce a case where it's not
   #   the last merge commit that is to be tested
   # - Aside of merge commit we need a previous commit to be able to detect a version switch

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,18 @@ before_script:
   # More info on below line: https://www.davidpashley.com/articles/writing-robust-shell-scripts/#idm5413512
   - set -e
 
+# Ensure to fail build if deploy fails, Travis doesn't ensure that: https://github.com/travis-ci/travis-ci/issues/921
+before_deploy:
+  # Remove eventual old npm logs
+  - rm -rf ~/.npm/_logs
+after_deploy:
+  - |
+    # npm creates log only on failure
+    if [ -d ~/.npm/_logs ]; then
+      # Undocumented way to force Travis build to fail
+      travis_terminate 1
+    fi
+
 jobs:
   include:
     # In most cases it's best to configure one job per platform & Node.js version combination

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "prettier-check-updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier -c",
     "prettify": "prettier --write --ignore-path .gitignore \"**/*.{css,html,js,json,md,yaml,yml}\""
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
- Travis by default restricts deploy to branch `master`, therefore it was not picked for [tag build](https://travis-ci.org/serverless/eslint-config/builds/549614414) as expected
- Ensured repo is configured with access public, as scope repositories on first publish are by default published as private and that incurs [npm error](https://docs.travis-ci.com/user/deployment/npm/#troubleshooting-npm-err-you-need-a-paid-account-to-perform-this-action)

--- 

_As. a workaround v1.0.0 was published via temporary hack commit -> https://travis-ci.org/serverless/eslint-config/builds/549620144_

---  

Additionally:
- Configure caching
- Ensure colored output
- Ensure to install latest versions of dependencies
- Workaround Travis issue, where further scripts are invoked after fail
- Ensure build fails if deploy fails