### PR TITLE
Turn off 'require-atomic-updates' rule due to false positives

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ module.exports = {
     'prefer-spread': 'error',
     'prefer-template': 'error',
     'radix': 'error',
+    'require-atomic-updates': 'off', // Reports false positives: https://github.com/eslint/eslint/issues/11899
     'vars-on-top': 'error',
     'spaced-comment': ['error', 'always', { exceptions: ['-', '+'], markers: ['=', '!'] }],
     'strict': ['error', 'safe'],


### PR DESCRIPTION
It's an unfortunate new addition to `eslint:recommended`

e.g. it reports errors for this lines: https://github.com/serverless/enterprise-plugin/blob/e25dfeedab8c3ed7583867261ef96aaee3e0f050/src/lib/credentials.js#L18-L20

More info: https://github.com/eslint/eslint/issues/11899

