### PR TITLE
Fix Prettier compliancy in 'no-confusing-arrow' rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
     'new-cap': ['error', { newIsCap: true }],
     'no-array-constructor': 'error',
     'no-caller': 'error',
-    'no-confusing-arrow': ['error', { allowParens: true }],
+    'no-confusing-arrow': ['error', { allowParens: false }],
     'no-console': 'error',
     'no-duplicate-imports': 'error',
     'no-else-return': 'error',


### PR DESCRIPTION
It was configured in way that conflicted with Prettier. More info: https://github.com/prettier/eslint-config-prettier#no-confusing-arrow