### PR TITLE
Recognize 'test' folders as test files source

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,15 @@ module.exports = {
     'import/no-duplicates': 'error',
     'import/no-extraneous-dependencies': [
       'error',
-      { devDependencies: ['**/*.test.js', '**/scripts/**', '**/tests/**', 'prettier.config.js'] },
+      {
+        devDependencies: [
+          '**/*.test.js',
+          '**/scripts/**',
+          '**/test/**',
+          '**/tests/**',
+          'prettier.config.js',
+        ],
+      },
     ],
     'import/no-mutable-exports': 'error',
     'import/no-named-as-default': 'error',


### PR DESCRIPTION
We recognize already a `tests` folder as source for test files, but it is more common to name folder with tests as `test`.

Ensure to also recognize it in context of `import/no-extraneous-dependencies` rule