### PR TITLE
Turn off prettier conflicting rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = {
     'array-callback-return': 'error',
     'block-scoped-var': 'error',
     'camelcase': ['error', { properties: 'never' }],
-    'comma-dangle': ['error', 'always-multiline'],
     'consistent-return': 'error',
     'curly': ['error', 'multi-line'],
     'default-case': ['error', { commentPattern: '^no default$' }],


### PR DESCRIPTION
With v6.6.0 ESlint improved handling of `comma-dangle` rule, and that exposed some _lint issues_ in our files -> https://travis-ci.org/serverless/serverless/jobs/603891215

Still our current Prettier configuration enforces commas only in ES5 safe syntax cases - while new ESlint update now enforces them in all cases

Whiile we can (with major bump) enforce trailing commas in all cases. It should be done purely in context of Prettier configration, and ESLint rule should be turned off to not conflict with its settings.

Technically it's a bug on our side, that rule is not turned off already, as it's marked as Prettier conflicting https://github.com/prettier/eslint-config-prettier/blob/b4ade2b09ea49fd4cdd11ec72fd93153fc3d69e9/index.js#L29

With this PR we turn off this ESLint rule