### PR TITLE
Recognize `BigInt` global

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -5,6 +5,7 @@ const { join } = require('path');
 module.exports = {
   // The only way to ensure that ESLint resolves expected config from any location
   extends: join(__dirname, '../index.js'),
+  globals: { BigInt: true },
   env: { node: true },
   rules: {
     'no-path-concat': 'error',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "serverless.com",
   "repository": "serverless/eslint-config",
   "eslintConfig": {
-    "extends": "./node",
+    "extends": "./node/6",
     "root": true
   },
   "standard-version": {
@@ -43,6 +43,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=6.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
While ES2020 feature, it is supported by Node.js v10

Additionally secure support for Node.js v6 (while by default it exports configuration that validates against Node.js v10 as minimal version, there's also `node/6` config provided for projects which are expected to still support Node.js v6, in such case this package should also be runnable in Node.js v6)