### PR TITLE
Do not recognize `BigInt` in Node.js v6

### DIFF
--- a/node/6.js
+++ b/node/6.js
@@ -5,4 +5,5 @@ const { join } = require('path');
 module.exports = {
   extends: join(__dirname, 'index.js'),
   parserOptions: { ecmaVersion: 2015 },
+  globals: { BigInt: 'off' },
 };

--- a/node/index.js
+++ b/node/index.js
@@ -5,7 +5,7 @@ const { join } = require('path');
 module.exports = {
   // The only way to ensure that ESLint resolves expected config from any location
   extends: join(__dirname, '../index.js'),
-  globals: { BigInt: true },
+  globals: { BigInt: 'readonly' },
   env: { node: true },
   rules: {
     'no-path-concat': 'error',


### PR DESCRIPTION
Accidentally sneaked a bug with the previous PR.

`BigInt` support needs to be reverted in Node.js v6 config file