### PR TITLE
feat: Allow ES2020 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 module.exports = {
   extends: 'eslint:recommended',
   env: { es6: true },
-  parserOptions: { ecmaVersion: 2019 },
+  parserOptions: { ecmaVersion: 2020 },
   plugins: ['import'],
   rules: {
     'array-callback-return': 'error',


### PR DESCRIPTION
I want to work on https://github.com/serverless/serverless/issues/10645.

It needs [dynamic import](https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_import_expressions), but the syntax require that `ecmaVersion` of parser options is 2020 or later.