### PR TITLE
Do not recognize `fetch` global in Node.js v12

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -5,7 +5,7 @@ const { join } = require('path');
 module.exports = {
   // The only way to ensure that ESLint resolves expected config from any location
   extends: join(__dirname, '../index.js'),
-  globals: { BigInt: 'readonly', globalThis: 'readonly' },
+  globals: { BigInt: 'readonly', fetch: 'off', globalThis: 'readonly' },
   env: { node: true },
   rules: {
     'no-path-concat': 'error',


### PR DESCRIPTION
ESlint whitelists this global for Node.js env in general, while it's supported starting from Node.js v18